### PR TITLE
fix(auth): authStore에서 토큰 저장 제거 및 상태 동기화 로직 수정 (#41)

### DIFF
--- a/src/app/(app)/meetings/[id]/page.tsx
+++ b/src/app/(app)/meetings/[id]/page.tsx
@@ -5,7 +5,7 @@ import Image from "next/image";
 import MeetingDetailCard from "@/components/meeting/MeetingDetailCard";
 import ParticipantList from "@/components/meeting/ParticipantList";
 import ReviewSection from "@/components/meeting/ReviewSection";
-import { useAuthStore } from "@/store/authStore";
+import { selectUser, useAuthStore } from "@/store/authStore";
 import { useState, useEffect } from "react";
 import { Gathering, GatheringParticipant } from "@/types/gathering";
 import { ReviewList } from "@/types/review";
@@ -15,7 +15,7 @@ export default function MeetingDetailPage() {
   const params = useParams();
   const meetingId = parseInt(params.id as string);
 
-  const { user } = useAuthStore();
+  const user = useAuthStore(selectUser);
   const [isFavorite, setIsFavorite] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [gathering, setGathering] = useState<Gathering | null>(null);
@@ -26,19 +26,19 @@ export default function MeetingDetailPage() {
   // Mock 데이터 로딩
   useEffect(() => {
     const loadMockData = async () => {
-        setIsLoading(true);
+      setIsLoading(true);
 
-        // TODO: 실제 API 호출로 대체 예정
-        const mockGathering = mockGatherings[meetingId];
-        const mockParticipantList = mockParticipants[meetingId] || [];
-        const mockReviewData = mockReviewsByGathering[meetingId];
+      // TODO: 실제 API 호출로 대체 예정
+      const mockGathering = mockGatherings[meetingId];
+      const mockParticipantList = mockParticipants[meetingId] || [];
+      const mockReviewData = mockReviewsByGathering[meetingId];
 
       setGathering(mockGathering || null);
       setParticipants(mockParticipantList);
       setReviewList(mockReviewData);
       setCurrentPage(mockReviewData?.currentPage || 1);
       setIsLoading(false);
-    }  
+    };
     loadMockData();
   }, [meetingId]);
 

--- a/src/components/my/hosted/CreatedCardList.tsx
+++ b/src/components/my/hosted/CreatedCardList.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { useGatherings } from "@/apis/gatherings/gatherings.query";
-import { useAuthStore } from "@/store/authStore";
+import { selectUser, useAuthStore } from "@/store/authStore";
 import Image from "next/image";
 import CreatedCardItem, { CreatedCardSkeleton } from "./CreatedCardItem";
 
 export default function CreatedCardList() {
-  const { user } = useAuthStore();
+  const user = useAuthStore(selectUser);
   const { isLoading, data } = useGatherings({ createdBy: user?.id });
 
   return isLoading ? (

--- a/src/components/my/profile/ProfileCard.tsx
+++ b/src/components/my/profile/ProfileCard.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import { useOverlay } from "@/hooks/useOverlay";
-import { useAuthStore } from "@/store/authStore";
+import { useAuthStore, selectUser } from "@/store/authStore";
 import { cn } from "@/utils/classNames";
 import Image from "next/image";
 import ProfileUpdateModal from "./ProfileUpdateModal";
 
 export default function ProfileCard() {
-  const { user } = useAuthStore();
+  const user = useAuthStore(selectUser);
   const { overlay } = useOverlay();
 
   function handleClickEdit() {

--- a/src/components/my/reviews/ReviewCardList.tsx
+++ b/src/components/my/reviews/ReviewCardList.tsx
@@ -3,7 +3,7 @@
 import { useJoinedGatherings } from "@/apis/gatherings/gatherings.query";
 import { useReviews } from "@/apis/reviews/reviews.query";
 import Chip from "@/components/ui/Chip";
-import { useAuthStore } from "@/store/authStore";
+import { selectUser, useAuthStore } from "@/store/authStore";
 import Image from "next/image";
 import { createContext, useContext, useState } from "react";
 import ReviewedCardItem, { ReviewCardSkeleton } from "./ReviewedCardItem";
@@ -64,7 +64,7 @@ function UnreviewedCardList() {
   );
 }
 function ReviewedCardList() {
-  const { user } = useAuthStore();
+  const user = useAuthStore(selectUser);
   const { isLoading, data } = useReviews({ userId: user?.id });
   return isLoading ? (
     <SkeletonList />


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 PR 유형
- [x] 버그 수정 (Bug Fix)
- [x] 코드 개선 (Refactoring)

---

## 🔍 변경 사항

- **authStore 리팩토링**
  - tokenStore로 토큰 관리 단일화  
  - authStore에서는 사용자 정보만 유지하도록 구조 단순화   
  - `AuthSnapshot` 타입 통합 및 `Partial<AuthState>`로 안정성 강화  

- **참조 컴포넌트 수정**
  - `ProfileCard`, `CreatedCardList`, `ReviewCardList`, `MeetingDetailPage`  
    → 렌더링 경고 방지 및 타입 일관성 보완  

- `/app/meetings/[id]/page.tsx`  
  → `useAuthStore(selectUser)` 적용만 하였으나 diff 발생  

- `/gatherings/joined` API 응답(`200 OK`) 확인으로 로그인 상태 정상 동작 검증 완료  

---

## 📸 스크린샷

<img width="399" height="603" alt="스크린샷 2025-10-14 오후 11 25 00" src="https://github.com/user-attachments/assets/202ca7a9-c8dd-4bdb-b922-ce9c28f3ec5d" />
<img width="877" height="618" alt="스크린샷 2025-10-14 오후 11 22 23" src="https://github.com/user-attachments/assets/cac36915-62fd-47f3-920c-66864c46d5e5" />
<img width="1013" height="687" alt="스크린샷 2025-10-14 오후 11 21 39" src="https://github.com/user-attachments/assets/b170c191-4bb1-4864-854c-893313000596" />

---

## 🚧 관련 이슈

Refs #41

---

## 💡 추가 정보

- 이번 수정은 **토큰 관리 책임을 분리**하여 인증 상태를 보다 명확히 유지하기 위한 리팩토링입니다.  
- UI/기능 변화 없이 내부 로직 및 참조 구조만 개선되었습니다.  


> **참고:**  
> 본 PR은 `signup` 브랜치에서 파생된 작업으로,  
> 회원가입 브랜치가 아직 main에 병합되지 않아 base를 `signup`으로 설정했습니다.  
> 실제 변경 범위는 **auth 관련 코드 리팩토링**만 포함됩니다.