### PR TITLE
fix(auth): 사용자 정보 스토어 동기화 로직 추가 (#41)

### DIFF
--- a/src/app/AppInitializer.tsx
+++ b/src/app/AppInitializer.tsx
@@ -3,10 +3,19 @@
 import { useEffect } from "react";
 import { setupAuthTokenSync } from "@/utils/auth/setupAuthTokenSync";
 
+/**
+ * AppInitializer
+ * - apiClient Authorization 헤더를 tokenStore와 동기화합니다.
+ * - 토큰 변경(AUTH_TOKEN_CHANGED / storage 이벤트) 시 즉시 반영됩니다.
+ */
+
 export default function AppInitializer() {
   useEffect(() => {
     const dispose = setupAuthTokenSync();
-    return dispose; // 리스너 정리
+
+    // StrictMode 중복 마운트 대비: 리스너 정리
+    return dispose;
   }, []);
+
   return null;
 }

--- a/src/app/GlobalAuthHydrator.tsx
+++ b/src/app/GlobalAuthHydrator.tsx
@@ -4,36 +4,33 @@
 import { useEffect } from "react";
 import { authActions } from "@/store/authStore";
 import { getAuthUser } from "@/apis/auths/auths.service";
-import { tokenStore, AUTH_TOKEN_CHANGED, ACCESS_TOKEN_KEY } from "@/utils/auth/token.store";
+import { tokenStore } from "@/utils/auth/token.store";
+import { onTokenChange } from "@/utils/auth/onTokenChange";
+
+/**
+ * GlobalAuthHydrator
+ * - 앱 전역에서 로그인 토큰을 감지하고 사용자 정보를 동기화합니다.
+ * - 첫 렌더링 시 1회 hydrateUser(getAuthUser) 실행
+ * - 이후 토큰 변경(AUTH_TOKEN_CHANGED / storage 이벤트) 시 자동 동기화
+ */
 
 export default function GlobalAuthHydrator() {
   useEffect(() => {
     const hydrate = async () => {
       const token = tokenStore.get();
       if (token) {
-        await authActions.hydrateUser(getAuthUser); // user 채우기
+        await authActions.hydrateUser(getAuthUser); // user 상태 채우기
       } else {
-        await authActions.clear(); // 로그아웃/토큰없음 → 비움
+        await authActions.clear(); // 로그아웃 or 토큰 없음 → 스토어 비움
       }
     };
 
-    // ① 앱 최초 로드 시 1회
+    // 앱 최초 렌더링 시 1회 실행
     hydrate();
-
-    // ② 토큰 변경(동일 탭)
-    const onChanged = hydrate as EventListener;
-    // ③ 다른 탭에서 토큰 변경
-    const onStorage = (e: StorageEvent) => {
-      if (e.key === ACCESS_TOKEN_KEY) hydrate();
-    };
-
-    window.addEventListener(AUTH_TOKEN_CHANGED, onChanged);
-    window.addEventListener("storage", onStorage);
-
-    return () => {
-      window.removeEventListener(AUTH_TOKEN_CHANGED, onChanged);
-      window.removeEventListener("storage", onStorage);
-    };
+    // 토큰 변경(동일 탭 or 다른 탭) 감지
+    const dispose = onTokenChange(hydrate);
+    // StrictMode 환경 중복 마운트 대비: 리스너 정리
+    return dispose;
   }, []);
 
   return null;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,9 +28,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="ko" className={`${pretendard.variable} ${tenada.variable}`}>
       <body className="flex min-h-dvh flex-col bg-gray-50">
-        {/* 앱 전역 초기화 (토큰 동기화, 리스너 등록)  */}
+        {/* Authorization 헤더 동기화 (토큰 변경 시 apiClient에 반영)  */}
         <AppInitializer />
-        {/* 토큰 존재 시 user 전역 하이드레이트 */}
+        {/* 토큰 존재 시 로그인 사용자 정보 하이드레이트 */}
         <GlobalAuthHydrator />
         <Providers>
           <MainNav />

--- a/src/utils/auth/onTokenChange.ts
+++ b/src/utils/auth/onTokenChange.ts
@@ -1,0 +1,27 @@
+// src/utils/auth/onTokenChange.ts
+"use client";
+import { AUTH_TOKEN_CHANGED, ACCESS_TOKEN_KEY } from "@/utils/auth/token.store";
+
+/**
+ * onTokenChange
+ * - 토큰 변경(AUTH_TOKEN_CHANGED, storage 이벤트)을 감지하여 handler 실행
+ * - setupAuthTokenSync, GlobalAuthHydrator 등에서 공통적으로 사용
+ * - 정리 함수를 반환하여 StrictMode 중복 마운트 시 리스너 누수 방지
+ */
+
+export function onTokenChange(handler: () => void) {
+  if (typeof window === "undefined") return () => {};
+
+  // 이벤트 리스너 등록
+  const onChanged = handler as EventListener;
+  const onStorage = (e: StorageEvent) => {
+    if (e.key === ACCESS_TOKEN_KEY) handler();
+  };
+  window.addEventListener(AUTH_TOKEN_CHANGED, onChanged);
+  window.addEventListener("storage", onStorage);
+  // 정리 함수 반환 (StrictMode 중복 마운트/언마운트 대비)
+  return () => {
+    window.removeEventListener(AUTH_TOKEN_CHANGED, onChanged);
+    window.removeEventListener("storage", onStorage);
+  };
+}

--- a/src/utils/auth/setupAuthTokenSync.ts
+++ b/src/utils/auth/setupAuthTokenSync.ts
@@ -1,7 +1,8 @@
 // src/utils/auth/setupAuthTokenSync.ts
 "use client";
-import { tokenStore, AUTH_TOKEN_CHANGED, ACCESS_TOKEN_KEY } from "@/utils/auth/token.store";
+import { tokenStore } from "@/utils/auth/token.store";
 import { apiClient } from "@/apis/_client";
+import { onTokenChange } from "./onTokenChange";
 
 /**
  * setupAuthTokenSync
@@ -12,24 +13,9 @@ import { apiClient } from "@/apis/_client";
 
 export function setupAuthTokenSync() {
   if (typeof window === "undefined") return () => {};
-
   // 토큰 동기화 함수
   const sync = () => apiClient.setAuthToken(tokenStore.get() ?? undefined);
-
   // 초기 1회 동기화
   sync();
-
-  // 이벤트 리스너 등록
-  const onChanged = sync as EventListener;
-  const onStorage = (e: StorageEvent) => {
-    if (e.key === ACCESS_TOKEN_KEY) sync();
-  };
-  window.addEventListener(AUTH_TOKEN_CHANGED, onChanged);
-  window.addEventListener("storage", onStorage);
-
-  // 정리 함수 반환 (StrictMode 중복 마운트/언마운트 대비)
-  return () => {
-    window.removeEventListener(AUTH_TOKEN_CHANGED, onChanged);
-    window.removeEventListener("storage", onStorage);
-  };
+  return onTokenChange(sync); // 토큰 변할 때마다 헤더 갱신
 }


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 PR 유형

- [x] 버그 수정 (Bug Fix)
- [x] 코드 개선 (Refactoring)

---

## 🔍 변경 사항

### 1) 중복 이벤트 로직 구조 정리
- 기존 `setupAuthTokenSync` 내부에서 직접 이벤트 리스너(`window.addEventListener`)를 등록하던 방식을  
  **`onTokenChange` 공통 유틸로 분리하여 중복 로직 제거**.
- 기존과 동일하게 **토큰 변경 시 `apiClient` Authorization 헤더 갱신**은 유지되며,  
  코드 구조만 단순화 및 관리 포인트를 통합했습니다.

### 2) 공통 유틸 추가
- `onTokenChange` 유틸 추가 → **동일 탭 / 다른 탭(localStorage)에서 발생한 토큰 변경 모두 감지**.  
- 이벤트 등록 및 해제 로직을 일원화하여 **StrictMode 환경에서도 안전하게 동작**하도록 개선.

### 3) 전역 유저 하이드레이션 로직 추가
- `GlobalAuthHydrator`를 도입하여  
  **앱 최초 로드 또는 토큰 변경 시 `getAuthUser`를 통해 유저 정보를 자동으로 동기화**.  
- 토큰이 없을 경우 `authStore.clear()`를 통해 안전하게 초기화.  
- 기존 `setupAuthTokenSync`와 역할을 분리하여  
  - `setupAuthTokenSync`: 헤더 동기화  
  - `GlobalAuthHydrator`: 사용자 데이터 동기화  
  로 명확히 구분됨.

> 결과적으로 기존 기능(헤더 갱신)은 그대로 유지하면서,
로그인 / 로그아웃 / 새 탭 로그인 등 등 모든 상황에서
> 헤더와 전역 사용자 상태가 즉시 일관되게 반영되도록 개선되었습니다.
> 코드 중복을 제거하고 이벤트 관리 방식을 정리하여,
전반적인 구조 안정성과 코드 가독성을 향상시켰습니다.

---

## 📸 스크린샷


---

## 🛠️ 테스트 방법

1. 로그인 후 새로고침 시에도 로그인 상태 및 프로필 정보 유지 확인.  
2. 다른 탭에서 로그인/로그아웃 시, 현재 탭에서도 **자동으로 상태 변경 반영** 확인.  
3. 마이페이지 진입 시 `GET /auths/user` 네트워크 응답 정상 및 사용자 정보 렌더링 확인.

---

## 🚧 관련 이슈

- 예: #41 (auth 관련 동기화 리팩토링)

---

## 💡 추가 정보

- `setupAuthTokenSync`: **기술적 상태(헤더)** 관리  
- `GlobalAuthHydrator`: **비즈니스 상태(user)** 관리  
- `onTokenChange`: 토큰 이벤트 구독의 **공통 관리 포인트**

위 세 모듈로 관심사를 명확히 분리하여 유지보수성을 향상시켰습니다.

---

## 🙏 리뷰어에게

- 마이페이지에서 유저정보 확인  
  - `/auths/user` 200 OK, 사용자 정보 정상 렌더(마이페이지)

---

### 참고
본 PR은 `signup` 브랜치에서 파생된 작업으로,  
회원가입 브랜치가 아직 develop에 병합되지 않아 **base를 `signup`으로 설정**했습니다.  
실제 변경 범위는 **auth 관련 코드 리팩토링 및 버그 수정**만 포함됩니다.
