### PR TITLE
feat(auth): 회원가입 훅 및 UI 리팩토링, 유효성 검증·에러 처리 개선 (#50)

### DIFF
--- a/src/apis/_client.ts
+++ b/src/apis/_client.ts
@@ -100,9 +100,9 @@ export class ApiClient {
       }
       const parsed = ApiErrorSchema.safeParse(raw);
       if (parsed.success) {
-        const { code, message } = parsed.data;
+        const { code, message, parameter } = parsed.data as any;
         const uiMsg = getErrorMessage(resp.status, code, message);
-        throw new HttpApiError(resp.status, uiMsg);
+        throw new HttpApiError(resp.status, uiMsg, code, parameter);
       }
 
       // 알 수 없는 포맷

--- a/src/apis/_errorMessage.ts
+++ b/src/apis/_errorMessage.ts
@@ -12,8 +12,8 @@ const ALLOW_SERVER_MSG = new Set([
   "VALIDATION_ERROR", // 400: 유효성 검증 실패 (parameter: 필드명 포함)
   "INVALID_CREDENTIALS", // 401: 비밀번호/아이디 불일치
   "USER_NOT_FOUND", // 404: 없는 계정
-  // "EMAIL_ALREADY_TAKEN", // 필요 시 서버 문구 그대로 노출 가능
   // "SERVER_ERROR" // 500: 서버 오류 (필요 시 활성화)
+  "EMAIL_EXISTS", // 이미 사용 중인 이메일입니다
 ]);
 
 export const getErrorMessage = (status?: number, code?: string, serverMsg?: string) => {

--- a/src/apis/auths/auths.service.ts
+++ b/src/apis/auths/auths.service.ts
@@ -25,13 +25,18 @@ import { tokenStore } from "@/utils/auth/token.store";
 
 /** 회원가입 (메시지 DTO) */
 export const signup = async (body: SignupBody): Promise<SignupResponse> => {
-  const parsed = SignupBodySchema.parse(body);
-  const res = await apiClient.post<SignupResponse>(
-    authEndpoints.signup(),
-    parsed,
-    SignupResponseSchema,
-  );
-  return res;
+  const parsed = SignupBodySchema.safeParse(body);
+  if (!parsed.success) {
+    const first = parsed.error.issues[0];
+    const field = Array.isArray(first?.path) ? String(first.path[0]) : undefined;
+    throw new HttpApiError(
+      400,
+      first?.message ?? "입력값을 확인해주세요.",
+      "VALIDATION_ERROR",
+      field,
+    );
+  }
+  return apiClient.post<SignupResponse>(authEndpoints.signup(), parsed.data, SignupResponseSchema);
 };
 
 /** 로그인 (토큰/메시지 DTO) - 토큰 저장 후 응답 반환 */

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -91,7 +91,6 @@ const LoginForm = ({ redirect = "/" }: Props) => {
 
       <label className="mt-4 mb-1 text-[13px] font-medium text-slate-500">비밀번호</label>
       <AuthPasswordInput
-        type="password"
         placeholder="비밀번호를 입력해 주세요"
         value={pw}
         onChange={(e) => setPw(e.target.value)}

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -2,15 +2,14 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { useRouter } from "next/navigation";
 import Link from "next/link";
 import AuthInput from "./ui/AuthInput";
 import { AuthPasswordInput } from "./ui/AuthPasswordInput";
 import AuthButton from "./ui/AuthButton";
-import { useSignup } from "@/hooks/auths/useSignUp";
-import { toSafePath } from "@/utils/auth/safePath";
+import { useSignup } from "@/hooks/auths/useSignup";
+// import { toSafePath } from "@/utils/auth/safePath";
 import {
-  toUserErrorMessage,
+  // toUserErrorMessage,
   toUserErrorDetails,
   extractValidationItems,
 } from "@/apis/_errorMessage";
@@ -20,9 +19,8 @@ import { MIN_PASSWORD_LEN } from "@/constants/auth/constraints";
 
 type Props = { redirect?: string };
 
-const SignupForm = ({ redirect = "/" }: Props) => {
-  const router = useRouter();
-  const { mutateAsync: signupMutate, isPending, error } = useSignup();
+const SignupForm = ({ redirect = "/signin" }: Props) => {
+  const { mutateAsync: signupMutate, isPending } = useSignup();
 
   // form states
   const [name, setName] = useState("");
@@ -37,7 +35,7 @@ const SignupForm = ({ redirect = "/" }: Props) => {
   const [companyError, setCompanyError] = useState("");
   const [pwError, setPwError] = useState("");
   const [pw2Error, setPw2Error] = useState("");
-  const [serverMsg, setServerMsg] = useState("");
+  //   const [serverMsg, setServerMsg] = useState("");
 
   // 앞단 검증
   const isPwMatch = pw2.length > 0 && pw === pw2;
@@ -45,7 +43,8 @@ const SignupForm = ({ redirect = "/" }: Props) => {
 
   // 버튼 활성: 값 존재 & 요청 중 아님 (검증은 submit 시 validateSignup이 최종 담당)
   const canSubmit = useMemo(
-    () => !!(name.trim() && email.trim() && company.trim() && pw && pw2) && !isPending,
+    () =>
+      !!(name.trim() && email.trim() && company.trim() && pw && pw2 && pw === pw2) && !isPending,
     [name, email, company, pw, pw2, isPending],
   );
 
@@ -59,7 +58,7 @@ const SignupForm = ({ redirect = "/" }: Props) => {
     setCompanyError("");
     setPwError("");
     setPw2Error("");
-    setServerMsg("");
+    // setServerMsg("");
 
     // 1) 클라이언트 선검증
     const errs = validateSignup({
@@ -85,19 +84,21 @@ const SignupForm = ({ redirect = "/" }: Props) => {
         companyName: company.trim(),
         password: pw,
       };
-      await signupMutate(body as any);
-      router.replace(toSafePath(redirect));
+      await signupMutate(body);
+      // 성공 모달은 useSignup 내부에서 처리 중
+      // 필요 시: router.replace(redirect);
     } catch (err) {
-      // 상단 배너 메시지
-      setServerMsg(toUserErrorMessage(err, AUTH_ERROR_MESSAGES.generic.SIGNUP_FAILED));
-
       // 서버 필드 에러 매핑(있으면)
-      const { code } = toUserErrorDetails(err, "");
-      if (code === "EMAIL_ALREADY_TAKEN") {
+      const { code, status } = toUserErrorDetails(err, "");
+
+      // 이메일 중복(서버: 400 + code "EMAIL_EXISTS")
+      if (code === "EMAIL_EXISTS") {
         setEmailError(AUTH_ERROR_MESSAGES.fields.email.DUPLICATE);
         return;
       }
-      if (code === "VALIDATION_ERROR") {
+
+      // 서버 유효성 오류 → 각 필드로 매핑하지만, 대부분은 프론트에서 선검증됨
+      if (code === "VALIDATION_ERROR" || status === 400 || status === 422) {
         const items = extractValidationItems(err);
         for (const it of items) {
           switch (it.parameter) {
@@ -113,17 +114,12 @@ const SignupForm = ({ redirect = "/" }: Props) => {
             case "password":
               setPwError(it.message || AUTH_ERROR_MESSAGES.fields.password.WEAK);
               break;
-            default:
-              break;
           }
         }
+        return;
       }
     }
   };
-
-  // React Query 에러 보조
-  const fallbackMsg = error ? toUserErrorMessage(error, "") : "";
-  const displayError = serverMsg || fallbackMsg;
 
   return (
     <form
@@ -132,10 +128,6 @@ const SignupForm = ({ redirect = "/" }: Props) => {
       className="flex w-[680px] max-w-full flex-col gap-2 rounded-2xl bg-white pt-14 pr-11 pb-11 pl-14 shadow-sm [box-shadow:0_1px_2px_rgba(0,0,0,0.04),0_8px_24px_rgba(16,24,40,0.08)]"
     >
       <h1 className="mb-6 text-center text-lg font-bold text-slate-900">회원가입</h1>
-
-      {displayError && (
-        <p className="mb-3 rounded-md bg-red-50 px-3 py-2 text-xs text-red-600">{displayError}</p>
-      )}
 
       {/* 이름 */}
       <label className="mb-1 text-[13px] font-medium text-slate-500">이름</label>
@@ -212,28 +204,13 @@ const SignupForm = ({ redirect = "/" }: Props) => {
         className="bg-white ring-1 ring-slate-200 hover:ring-[#5865F2]/40 focus-visible:ring-2 focus-visible:ring-[#5865F2]"
       />
 
-      {/* 비밀번호 확인 (이미지처럼 에러 보더 + 하단 메시지) */}
-      <label className="mt-4 mb-1 text-[13px] font-medium text-slate-500">비밀번호 확인</label>
-      <AuthPasswordInput
-        placeholder="비밀번호를 작성해 주세요"
-        value={pw2}
-        onChange={(e) => setPw2(e.target.value)}
-        invalid={!!pw2Error || (pw2.length > 0 && !isPwMatch)}
-        errorMessage={
-          pw2Error || (pw2.length > 0 && !isPwMatch ? "비밀번호가 일치하지 않습니다." : undefined)
-        }
-        aria-describedby="pw2-error"
-        autoComplete="new-password"
-        className="bg-white ring-1 ring-slate-200 hover:ring-[#5865F2]/40 focus-visible:ring-2 focus-visible:ring-[#5865F2]"
-      />
-
       {/* 실시간 힌트(선택): 최소 길이 */}
-      {pw.length > 0 && !isPwStrongEnough && (
+      {pw.length > 0 && !isPwStrongEnough && !pwError && (
         <p className="mt-1 text-xs text-[#FF2727]">
           비밀번호는 {MIN_PASSWORD_LEN}자 이상이어야 합니다.
         </p>
       )}
-      {/* 비밀번호 확인 */}
+      {/* 비밀번호 확인 (이미지처럼 에러 보더 + 하단 메시지)  */}
       <label className="mt-4 mb-1 text-[13px] font-medium text-slate-500">비밀번호 확인</label>
       <AuthPasswordInput
         placeholder="비밀번호를 작성해 주세요"

--- a/src/components/common/SignupModal.tsx
+++ b/src/components/common/SignupModal.tsx
@@ -1,0 +1,31 @@
+// src/components/common/SignupModal.tsx
+"use client";
+
+import { useOverlay } from "@/hooks/useOverlay";
+import Modal from "@/components/common/Modal";
+
+interface SignupModalProps {
+  title?: string;
+  message: string;
+  onConfirm?: () => void;
+}
+
+export default function SignupModal({ title, message, onConfirm }: SignupModalProps) {
+  const { close } = useOverlay();
+  const handleConfirm = () => {
+    onConfirm?.();
+    close();
+  };
+
+  return (
+    <Modal className="gap-10 p-6 md:gap-16 md:p-10">
+      <div className="grid gap-6">
+        <Modal.Header>{title}</Modal.Header>
+        <div className="flex-center text-center text-lg font-semibold md:text-2xl">
+          <p className="text-center whitespace-pre-line">{message}</p>
+        </div>
+      </div>
+      <Modal.OneButton onClick={handleConfirm}>확인</Modal.OneButton>
+    </Modal>
+  );
+}

--- a/src/constants/auth/errorMessages.ts
+++ b/src/constants/auth/errorMessages.ts
@@ -42,7 +42,7 @@ export const AUTH_ERROR_MESSAGES = {
   codes: {
     INVALID_CREDENTIALS: "아이디 또는 비밀번호가 올바르지 않아요.",
     USER_NOT_FOUND: "가입되지 않은 계정이에요.",
-    EMAIL_ALREADY_TAKEN: "이미 사용 중인 이메일이에요.", // 서버 중복 응답 폴백
+    EMAIL_EXISTS: "이미 사용 중인 이메일이에요.", // 서버 중복 응답 폴백
     VALIDATION_ERROR: "입력값을 다시 확인해 주세요.",
   },
 

--- a/src/hooks/auths/useSignup.tsx
+++ b/src/hooks/auths/useSignup.tsx
@@ -8,32 +8,43 @@ import { authQueryKeys } from "@/utils/auth/authQueryKeys";
 import { invalidateAuth } from "@/apis/_react_query/utils";
 import type { SignupBody, SignupResponse } from "@/apis/auths/auths.schema";
 import { tokenStore } from "@/utils/auth/token.store";
+import { useOverlay } from "../useOverlay";
+import { useRouter } from "next/navigation";
+import SignupModal from "@/components/common/SignupModal";
 
 /**
  * useSignup
- * - 기본: 가입만 (invalidate 없음)
- * - 옵션: autoLogin=true 이고 서버가 토큰을 주면 → 토큰 저장 후 인증 캐시 무효화(invalidate)
+ * - 기본: 가입 완료 시 모달 표시 후 로그인 페이지로 이동
+ * - (옵션): 추후 autoLogin=true 설정 시 → 서버가 토큰을 주면 → 토큰 저장 후 인증 캐시 무효화(invalidate)
  */
 
 export const useSignup = (options?: { autoLogin?: boolean }) => {
   const { autoLogin = false } = options ?? {};
   const queryClient = useQueryClient();
+  const { overlay } = useOverlay();
+  const router = useRouter();
 
   return useMutation<SignupResponse, Error, SignupBody>({
     mutationKey: authQueryKeys.mutation.signup(),
     mutationFn: signup,
     onSuccess: async (res) => {
-      //  if (!options?.autoLogin) return;
+      overlay(
+        <SignupModal
+          message={"가입이 완료되었습니다!\n로그인 페이지로 이동합니다."}
+          onConfirm={() => router.push("/signin")}
+        />,
+      );
+
       if (!autoLogin) return;
 
-      // 서버 응답 내 토큰 키 대응 (token | accessToken | access_token)
-      const r = res as any;
-      const maybeToken = r?.token ?? r?.accessToken ?? r?.access_token;
+      // 자동 로그인 로직 (현재 미사용 — 추후 필요 시 활성화)
+      // const r = res as any;
+      // const maybeToken = r?.token ?? r?.accessToken ?? r?.access_token;
 
-      if (typeof maybeToken === "string" && maybeToken) {
-        tokenStore.set(maybeToken);
-        await invalidateAuth(queryClient); // me/roles 등 인증 캐시 무효화
-      }
+      // if (typeof maybeToken === "string" && maybeToken) {
+      //   tokenStore.set(maybeToken);
+      //   await invalidateAuth(queryClient); // me/roles 등 인증 캐시 무효화
+      // }
     },
   });
 };


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 PR 유형
- [x] 기능 추가 (Feature)
- [x] 코드 개선 (Refactoring)
- [x] 스타일 변경 (UI/UX)
- [ ] 버그 수정 (Bug Fix)
- [ ] 기타 (Other)

---

## 🔍 변경 사항

- 회원가입 완료 시 SignupModal 노출 후 로그인 페이지로 이동하도록 변경  
- useSignup 훅 파일 확장자 변경 (useSignUp.ts → useSignup.tsx)  
- useSignup 훅 내부 autoLogin 로직 주석 처리 및 주석 구조 정리  
- SignupForm, LoginForm 내 불필요한 코드 및 주석 일부 정리  
- 회원가입 요청 시 Zod safeParse 기반 유효성 검증 추가  
  → 유효하지 않은 입력값에 대해 HttpApiError(400) 발생  
- 공통 Modal 스타일 유지하며 SignupModal 신규 추가 

---

## 📸 스크린샷
<img width="618" height="780" alt="스크린샷 2025-10-18 오전 3 25 06" src="https://github.com/user-attachments/assets/e4a5834c-9dd6-42f2-8f6a-a16391b53cbc" />
<img width="587" height="766" alt="스크린샷 2025-10-18 오전 3 25 24" src="https://github.com/user-attachments/assets/c5be668d-d851-4823-a6c5-d319cf1a3a49" />
<img width="1249" height="773" alt="스크린샷 2025-10-18 오전 3 25 41" src="https://github.com/user-attachments/assets/a3a19414-1cbd-4756-ae36-59ec1ba6b77b" />
<img width="564" height="709" alt="스크린샷 2025-10-18 오전 3 25 50" src="https://github.com/user-attachments/assets/6760c07e-d7d6-40a6-932d-fc8e2ad0fb2f" />
<img width="556" height="696" alt="스크린샷 2025-10-18 오전 3 26 03" src="https://github.com/user-attachments/assets/8def1a7c-daa2-4c6a-9740-402c375d2dda" />
<img width="558" height="699" alt="스크린샷 2025-10-18 오전 3 26 09" src="https://github.com/user-attachments/assets/e1b1b6bd-85ac-4e0e-b368-6ff4f3e04c81" />
<img width="1507" height="790" alt="스크린샷 2025-10-18 오전 3 27 12" src="https://github.com/user-attachments/assets/a404516b-c447-4aa8-9822-0d2a44e6ea9c" />
<img width="1511" height="688" alt="스크린샷 2025-10-18 오전 3 27 18" src="https://github.com/user-attachments/assets/97861f51-a396-4b4e-8061-278fe9db2028" />

---

## 🌐 테스트 링크
🔗 **Preview URL:**  
[https://devmeet-git-feature-50-auth-signup-api-codeit-sprint11-team-6.vercel.app/](https://devmeet-git-feature-50-auth-signup-api-codeit-sprint11-team-6.vercel.app/)

---

## 🛠️ 테스트 방법
1. 회원가입 폼 입력 후 제출
2. 입력값이 유효하지 않을 경우 클라이언트에서 선검증 메시지 확인
3. 이미 등록된 이메일 사용 시 중복 에러 메시지 확인
4. 회원가입 완료 시 `SignupModal` 노출 및 로그인 페이지 이동 확인

---

## 🚧 관련 이슈
- #50
