### PR TITLE
test(auth): 로그인/회원가입 및 Auth UI 컴포넌트 테스트 추가 (#99)

### DIFF
--- a/src/test/components/auth/LoginForm.test.tsx
+++ b/src/test/components/auth/LoginForm.test.tsx
@@ -18,7 +18,7 @@ jest.mock("@/apis/auths/auths.query", () => ({
 }));
 
 describe("LoginForm", () => {
-  it("유효 입력 시 버튼 활성화 & 제출 플로우", async () => {
+  test("유효 입력 시 버튼 활성화 & 제출 플로우", async () => {
     render(<LoginForm redirect="/" />);
     await userEvent.type(screen.getByLabelText(/아이디\(이메일\)/i), "tester@example.com");
     await userEvent.type(screen.getByLabelText(/^비밀번호$/i), "Abcd1234!!");

--- a/src/test/components/auth/SignupForm.test.tsx
+++ b/src/test/components/auth/SignupForm.test.tsx
@@ -41,7 +41,7 @@ describe("SignupForm", () => {
     pushMock.mockReset();
   });
 
-  it("비밀번호 확인 불일치 시 버튼 비활성화", async () => {
+  test("비밀번호 확인 불일치 시 버튼 비활성화", async () => {
     render(<SignupForm />);
     await userEvent.type(screen.getByLabelText(/이름/i), "홍길동");
     await userEvent.type(screen.getByLabelText(/아이디\(이메일\)/i), "user@example.com");
@@ -52,7 +52,7 @@ describe("SignupForm", () => {
     expect(screen.getByRole("button", { name: /회원가입/i })).toBeDisabled();
   });
 
-  it("정상 입력 시 mutateAsync 호출 + overlay 호출", async () => {
+  test("정상 입력 시 mutateAsync 호출 + overlay 호출", async () => {
     signupAsyncMock.mockResolvedValueOnce({ ok: true });
 
     render(<SignupForm redirect="/signin" />);
@@ -72,7 +72,7 @@ describe("SignupForm", () => {
     expect(overlaySpy).toHaveBeenCalledTimes(1);
   });
 
-  it("서버가 EMAIL_EXISTS 반환 시 이메일 중복 에러 노출", async () => {
+  test("서버가 EMAIL_EXISTS 반환 시 이메일 중복 에러 노출", async () => {
     signupAsyncMock.mockRejectedValueOnce({ code: "EMAIL_EXISTS", status: 400 });
 
     render(<SignupForm />);

--- a/src/test/components/auth/ui/AuthButton.test.tsx
+++ b/src/test/components/auth/ui/AuthButton.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from "@testing-library/react";
 import AuthButton from "@/components/auth/ui/AuthButton";
 
 describe("AuthButton", () => {
-  it("loading일 때 disabled + '처리 중...' 노출", () => {
+  test("loading일 때 disabled + '처리 중...' 노출", () => {
     render(<AuthButton loading>로그인</AuthButton>);
     const btn = screen.getByRole("button");
     expect(btn).toBeDisabled();
@@ -13,7 +13,7 @@ describe("AuthButton", () => {
     expect(btn).toHaveTextContent("처리 중...");
   });
 
-  it("enabled일 때 children 렌더링, 전체폭 적용", () => {
+  test("enabled일 때 children 렌더링, 전체폭 적용", () => {
     render(<AuthButton>회원가입</AuthButton>);
     const btn = screen.getByRole("button", { name: "회원가입" });
     expect(btn).toBeEnabled();

--- a/src/test/components/auth/ui/AuthInput.test.tsx
+++ b/src/test/components/auth/ui/AuthInput.test.tsx
@@ -3,14 +3,14 @@ import { render, screen } from "@testing-library/react";
 import AuthInput from "@/components/auth/ui/AuthInput";
 
 describe("AuthInput", () => {
-  it("invalid + errorMessage 시 aria-invalid/메시지 노출", () => {
+  test("invalid + errorMessage 시 aria-invalid/메시지 노출", () => {
     render(<AuthInput aria-label="이메일" invalid errorMessage="형식이 올바르지 않습니다" />);
     const input = screen.getByLabelText("이메일");
     expect(input).toHaveAttribute("aria-invalid", "true");
     expect(screen.getByText("형식이 올바르지 않습니다")).toBeInTheDocument();
   });
 
-  it("rightAdornment 렌더링", () => {
+  test("rightAdornment 렌더링", () => {
     render(<AuthInput aria-label="필드" rightAdornment={<span data-testid="addon">A</span>} />);
     expect(screen.getByTestId("addon")).toBeInTheDocument();
   });

--- a/src/test/components/auth/ui/AuthPasswordInput.test.tsx
+++ b/src/test/components/auth/ui/AuthPasswordInput.test.tsx
@@ -5,7 +5,7 @@ import userEvent from "@testing-library/user-event";
 import { AuthPasswordInput } from "@/components/auth/ui/AuthPasswordInput";
 
 describe("AuthPasswordInput", () => {
-  it("기본은 password → 토글하면 text 로 변경", async () => {
+  test("기본은 password → 토글하면 text 로 변경", async () => {
     render(<AuthPasswordInput aria-label="비밀번호" />);
     const input = screen.getByLabelText("비밀번호") as HTMLInputElement;
     expect(input.type).toBe("password");


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 PR 유형

- [x] 테스트 추가 (Test)

---

## 🔍 변경 사항  
- **LoginForm.test.tsx**: 로그인 유효 입력 및 리다이렉트 플로우 테스트  
- **SignupForm.test.tsx**: 회원가입 유효 입력/중복 이메일/오류 상태 검증  
- **AuthButton.test.tsx**: 로딩 상태 및 비활성화 스타일 검증  
- **AuthInput.test.tsx**: invalid/errorMessage 및 rightAdornment 렌더링 테스트  
- **AuthPasswordInput.test.tsx**: 비밀번호 표시/숨기기 토글 동작 테스트  

---

## 🛠️ 테스트 방법  
1. `npm run test` 실행  
2. 모든 Auth 관련 테스트(`LoginForm`, `SignupForm`, `AuthButton`, `AuthInput`, `AuthPasswordInput`)가 정상 통과되는지 확인  

---

## 🚧 관련 이슈  
Closes #99  

---

## 💡 추가 정보  
- 테스트 환경은 `jest + @testing-library/react` 기반  
- Auth UI 및 폼의 유효성 검증 로직과 사용자 입력 흐름을 커버  
- 비동기 처리(mocked mutation, overlay 동작 등) 포함 테스트 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * 테스트 케이스 검증 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->